### PR TITLE
Remove TODO that has been done (polling interval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ These features are on my wishlist and need to be implemented:
 
 - Implement devices that are not supported yet.
 - Add option to enable/disable state caching.
-- Add option to change polling frequency to user defined value (default is now 10 seconds).
 
 ## Unit tests
 


### PR DESCRIPTION
Noticed this was in the TODO section, but an option has already been added.