### PR TITLE
Update Conditional to account for "Colour" in the color mode property.

### DIFF
--- a/lib/light_accessory.js
+++ b/lib/light_accessory.js
@@ -73,7 +73,7 @@ class LightAccessory extends BaseAccessory {
             let rawValue;
             let percentage;
 
-            if (data.color_mode == 'color') {
+            if (data.color_mode == 'color' || data.color_mode == 'colour') {
               rawValue = data.color.brightness;   // 0-100 
               percentage = rawValue;
             } else {
@@ -226,7 +226,7 @@ class LightAccessory extends BaseAccessory {
       let rawValue;
       let percentage;
 
-      if (data.color_mode == 'color') {
+      if (data.color_mode == 'color' || data.color_mode == 'colour' {
         rawValue = data.color.brightness;   // 0-100 
         percentage = rawValue;
       } else {
@@ -243,7 +243,7 @@ class LightAccessory extends BaseAccessory {
       let rawValue;
       let percentage;
 
-      if (data.color_mode == 'color') {
+      if (data.color_mode == 'color' || data.color_mode == 'colour' {
         rawValue = data.color.brightness;   // 0-100 
         percentage = rawValue;
       } else {


### PR DESCRIPTION
It appears some devices return "colour" not "color". This definitely causes issue when parsing out the Saturation and Brightness, and helps resolve some of the issues with specific RGB Strips. There appears to still be an issue with Saturation specifically, but trying to sort through that next.